### PR TITLE
Reia 96 100 generate restock orders

### DIFF
--- a/backend/models/order.py
+++ b/backend/models/order.py
@@ -9,6 +9,7 @@ class Order(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
     deleted_at = Column(TIMESTAMP, nullable=True)
+    submitted_at = Column(TIMESTAMP, nullable=True)
     submitted = Column(Boolean, default=False)
 
     # Foreign key to User

--- a/backend/models/order.py
+++ b/backend/models/order.py
@@ -4,13 +4,15 @@ from database import Base # Base for model inheritance
 
 # Define the Order model
 class Order(Base):
-    __tablename__ = "orders"  # Table name in the database
+    __tablename__ = "orders"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)  # Unique identifier for each order
-    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())  # Timestamp when the order was created
-    deleted_at = Column(TIMESTAMP, nullable=True) # soft delete timestamp
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
+    deleted_at = Column(TIMESTAMP, nullable=True)
     submitted = Column(Boolean, default=False)
 
+    # Foreign key to User
+    created_by_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_by = relationship("User", back_populates="orders")  # Use 'orders' on User side
 
-    # Define relationships
-    order_items = relationship("OrderItem", back_populates="order", cascade="all, delete-orphan") # Items within this order
+    order_items = relationship("OrderItem", back_populates="order", cascade="all, delete-orphan")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -21,3 +21,4 @@ class User(Base):
     # Define relationships
     items_added = relationship("Item", back_populates="added_by", passive_deletes=True)  # Keep items, but make FKs null
     transactions = relationship("Transaction", back_populates="user", passive_deletes=True)  # User's transactions - keep transaction history
+    orders = relationship("Order", back_populates="created_by", passive_deletes=True)

--- a/backend/routes/orders.py
+++ b/backend/routes/orders.py
@@ -173,11 +173,11 @@ def submit_order(order_id: int, db: Session = Depends(get_db)):
         print(f"[ORDER-SUBMIT] Restocked '{item.name}' (id={item.id}) with +{order_item.final_quantity}")
 
     order.submitted = True
+    order.submitted_at = datetime.utcnow()
     db.commit()
     db.refresh(order)
 
-    print(f"[ORDER-SUBMIT] Order id={order.id} submitted at {order.created_at}")
-
+    print(f"[ORDER-SUBMIT] Order id={order.id} submitted at {order.submitted_at}")
     return order
 
 

--- a/backend/schemas/orders.py
+++ b/backend/schemas/orders.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from typing import List, Optional
 from datetime import datetime
 from schemas.items import ItemResponse 
+from schemas.users import UserResponse
 
 # base schema for an order item
 class OrderItemBase(BaseModel):
@@ -39,7 +40,9 @@ class OrderResponse(OrderBase):
     created_at: datetime
     deleted_at: Optional[datetime] = None  # soft delete tracking
     submitted: bool  
-    order_items: List[OrderItemResponse]  # nested order items
+    order_items: List[OrderItemResponse] # nested order items
+    created_by_id: Optional[int] = None
+
 
     class Config:
         from_attributes = True

--- a/backend/schemas/orders.py
+++ b/backend/schemas/orders.py
@@ -40,6 +40,7 @@ class OrderResponse(OrderBase):
     created_at: datetime
     deleted_at: Optional[datetime] = None  # soft delete tracking
     submitted: bool  
+    submitted_at: Optional[datetime] = None
     order_items: List[OrderItemResponse] # nested order items
     created_by_id: Optional[int] = None
     created_by: Optional[UserResponse] = None 

--- a/backend/schemas/orders.py
+++ b/backend/schemas/orders.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import datetime
+from schemas.items import ItemResponse 
 
 # base schema for an order item
 class OrderItemBase(BaseModel):
@@ -18,6 +19,8 @@ class OrderItemResponse(OrderItemBase):
     id: int
     created_at: datetime
     deleted_at: Optional[datetime] = None  # soft delete tracking
+    withdrawn_7d: Optional[int] = None
+    item: Optional[ItemResponse] = None
 
     class Config:
         from_attributes = True
@@ -40,3 +43,5 @@ class OrderResponse(OrderBase):
 
     class Config:
         from_attributes = True
+
+OrderItemResponse.update_forward_refs()

--- a/backend/schemas/orders.py
+++ b/backend/schemas/orders.py
@@ -42,7 +42,7 @@ class OrderResponse(OrderBase):
     submitted: bool  
     order_items: List[OrderItemResponse] # nested order items
     created_by_id: Optional[int] = None
-
+    created_by: Optional[UserResponse] = None 
 
     class Config:
         from_attributes = True

--- a/backend/schemas/orders.py
+++ b/backend/schemas/orders.py
@@ -44,4 +44,9 @@ class OrderResponse(OrderBase):
     class Config:
         from_attributes = True
 
+class OrderItemUpdate(BaseModel):
+    item_id: int
+    final_quantity: int
+
+
 OrderItemResponse.update_forward_refs()

--- a/database/README.md
+++ b/database/README.md
@@ -74,6 +74,12 @@ mysql -u root -p inventory < database/main.sql
 ```
 Replace `inventory` with your database name if different.
 
+You can also run this to reset the database schema:
+```sh
+use inventory
+source <absolute filepath to main.sql>
+```
+
 **Reminder**: this will wipe any exisiting data and replace it with whatever is in updated `main.sql`.
 
 

--- a/database/main.sql
+++ b/database/main.sql
@@ -69,7 +69,10 @@ CREATE TABLE orders (
     id INT AUTO_INCREMENT PRIMARY KEY,
     submitted BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- when that order was generated
-    deleted_at TIMESTAMP NULL DEFAULT NULL -- added for soft delete instead of full removal
+    deleted_at TIMESTAMP NULL DEFAULT NULL, -- added for soft delete instead of full removal
+    created_by_id INT, -- NEW: associate order with a user (admin)
+    FOREIGN KEY (created_by_id) REFERENCES users(id) ON DELETE SET NULL -- track who created it
+
 );
 
 -- order items table (Tracks individual items within an order when order is generated)

--- a/database/main.sql
+++ b/database/main.sql
@@ -71,6 +71,7 @@ CREATE TABLE orders (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- when that order was generated
     deleted_at TIMESTAMP NULL DEFAULT NULL, -- added for soft delete instead of full removal
     created_by_id INT, -- NEW: associate order with a user (admin)
+    submitted_at TIMESTAMP NULL DEFAULT NULL, -- added to get time when order was submitted
     FOREIGN KEY (created_by_id) REFERENCES users(id) ON DELETE SET NULL -- track who created it
 
 );

--- a/frontend/src/pages/admin/GenerateRestockPage.css
+++ b/frontend/src/pages/admin/GenerateRestockPage.css
@@ -1,0 +1,48 @@
+.generate-restock-container {
+    padding: 2rem;
+  }
+  
+  .restock-table {
+    width: 100%;
+    margin-top: 1rem;
+    border-collapse: collapse;
+  }
+  
+  .restock-table th, .restock-table td {
+    padding: 10px;
+    border: 1px solid #ccc;
+    text-align: center;
+  }
+  
+  .submit-btn {
+    margin-top: 1rem;
+    padding: 10px 15px;
+    font-weight: bold;
+  }
+  
+  .error-msg {
+    color: red;
+    margin-top: 1rem;
+  }
+
+  .order-meta {
+    font-size: 0.95rem;
+    color: #444;
+    margin-bottom: 1rem;
+    font-style: italic;
+  }
+
+  .toast-notification {
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #4caf50;
+    color: white;
+    padding: 12px 20px;
+    border-radius: 6px;
+    font-weight: bold;
+    z-index: 9999;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  }
+  

--- a/frontend/src/pages/admin/GenerateRestockPage.css
+++ b/frontend/src/pages/admin/GenerateRestockPage.css
@@ -1,48 +1,83 @@
 .generate-restock-container {
-    padding: 2rem;
-  }
-  
-  .restock-table {
-    width: 100%;
-    margin-top: 1rem;
-    border-collapse: collapse;
-  }
-  
-  .restock-table th, .restock-table td {
-    padding: 10px;
-    border: 1px solid #ccc;
-    text-align: center;
-  }
-  
-  .submit-btn {
-    margin-top: 1rem;
-    padding: 10px 15px;
-    font-weight: bold;
-  }
-  
-  .error-msg {
-    color: red;
-    margin-top: 1rem;
-  }
+  padding: 2rem;
+}
 
-  .order-meta {
-    font-size: 0.95rem;
-    color: #444;
-    margin-bottom: 1rem;
-    font-style: italic;
-  }
+.restock-table {
+  width: 100%;
+  margin-top: 1rem;
+  border-collapse: collapse;
+}
 
-  .toast-notification {
-    position: fixed;
-    top: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #4caf50;
-    color: white;
-    padding: 12px 20px;
-    border-radius: 6px;
-    font-weight: bold;
-    z-index: 9999;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  }
-  
+.restock-table th, .restock-table td {
+  padding: 10px;
+  border: 1px solid #ccc;
+  text-align: center;
+}
+
+/* .submit-btn {
+  margin-top: 1rem;
+  padding: 10px 15px;
+  font-weight: bold;
+} */
+
+.error-msg {
+  color: red;
+  margin-top: 1rem;
+}
+
+.order-meta {
+  font-size: 0.95rem;
+  color: #444;
+  margin-bottom: 1rem;
+  font-style: italic;
+}
+
+.toast-notification {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #4caf50;
+  color: white;
+  padding: 12px 20px;
+  border-radius: 6px;
+  font-weight: bold;
+  z-index: 9999;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+
+.submit-btn {
+  margin-top: 1.5rem;
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: white;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.submit-btn:hover {
+  background-color: #0056b3;
+}
+
+.restock-table td > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.restock-table input[type="text"] {
+  width: 45px;
+  padding: 4px;
+  text-align: center;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -47,20 +47,39 @@ export default function GenerateRestockPage() {
 
   const submitOrder = async () => {
     if (!order) return;
-
+  
     try {
+      // STEP 1: Update the final quantities first
+      const updatedItems = order.order_items.map((item) => ({
+        item_id: item.item_id,
+        final_quantity: item.final_quantity,
+      }));
+  
+      await axios.put(
+        `http://localhost:8000/orders/${order.id}/items`,
+        updatedItems,
+        {
+          headers: {
+            Authorization: `Bearer ${currentUser.token}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+  
+      // STEP 2: Then submit the order
       await axios.post(
         `http://localhost:8000/orders/${order.id}/submit`,
         {},
         {
-          headers: { Authorization: `Bearer ${currentUser.token}` },
+          headers: {
+            Authorization: `Bearer ${currentUser.token}`,
+          },
         }
       );
-
+  
       setShowSuccess(true);
       setOrder(null);
-
-      // wait 2 seconds, then hide redirect
+  
       setTimeout(() => {
         setShowSuccess(false);
         navigate("/admin/dashboard");
@@ -70,6 +89,7 @@ export default function GenerateRestockPage() {
       alert("Submission failed.");
     }
   };
+
 
 
 
@@ -91,7 +111,7 @@ export default function GenerateRestockPage() {
 
         {!order && (
           <button onClick={generateOrder} disabled={loading}>
-            {loading ? "Generating..." : "Generate Suggested Order"}
+            {loading ? "Generating..." : "Generate Restock Order"}
           </button>
         )}
 

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -1,4 +1,145 @@
-// GenerateRestockPage.jsx
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useAuth } from "../../contexts/AuthContext";
+import "./GenerateRestockPage.css";
+import { useNavigate } from "react-router-dom";
+
+
 export default function GenerateRestockPage() {
-  return <h1>Generate Restock Order Page</h1>;
+  const { currentUser } = useAuth();
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const navigate = useNavigate();
+
+
+
+  // generate suggested restock order
+  const generateOrder = async () => {
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const res = await axios.post("http://localhost:8000/orders/", {}, {
+        headers: { Authorization: `Bearer ${currentUser.token}` },
+      });
+      setOrder(res.data);
+    } catch (err) {
+      console.error(err);
+      setErrorMsg(err.response?.data?.detail || "Failed to generate order.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // update final_quantity in local state
+  const updateFinalQty = (itemId, value) => {
+    setOrder((prev) => ({
+      ...prev,
+      order_items: prev.order_items.map((item) =>
+        item.item_id === itemId
+          ? { ...item, final_quantity: parseInt(value) || 0 }
+          : item
+      ),
+    }));
+  };
+
+  const submitOrder = async () => {
+    if (!order) return;
+
+    try {
+      await axios.post(
+        `http://localhost:8000/orders/${order.id}/submit`,
+        {},
+        {
+          headers: { Authorization: `Bearer ${currentUser.token}` },
+        }
+      );
+
+      setShowSuccess(true);
+      setOrder(null);
+
+      // wait 2 seconds, then hide redirect
+      setTimeout(() => {
+        setShowSuccess(false);
+        navigate("/admin/dashboard");
+      }, 2000);
+    } catch (err) {
+      console.error(err);
+      alert("Submission failed.");
+    }
+  };
+
+
+
+  return (
+    <>
+      {showSuccess && (
+        <div className="toast-notification">
+          Order submitted and inventory updated!
+        </div>
+      )}
+
+      <div className="generate-restock-container">
+        {order && (
+          <p className="order-meta">
+            Order #{order.id} created on{" "}
+            {new Date(order.created_at).toLocaleString()} by {currentUser.name}
+          </p>
+        )}
+
+        {!order && (
+          <button onClick={generateOrder} disabled={loading}>
+            {loading ? "Generating..." : "Generate Suggested Order"}
+          </button>
+        )}
+
+        {errorMsg && <p className="error-msg">{errorMsg}</p>}
+
+        {order && (
+          <>
+            <table className="restock-table">
+              <thead>
+                <tr>
+                  <th>Item Name</th>
+                  <th>Item ID</th>
+                  <th>Current Stock</th>
+                  <th>Withdrawn (7d)</th>
+                  <th>Suggested Qty</th>
+                  <th>Final Qty</th>
+                </tr>
+              </thead>
+              <tbody>
+                {order.order_items.map((item) => (
+                  <tr key={item.id}>
+                    <td>{item.item?.name || "Unknown"}</td>
+                    <td>{item.item_id}</td>
+                    <td>{item.item?.quantity ?? "?"}</td>
+                    <td>{item.withdrawn_7d ?? "0"}</td>
+                    <td>{item.suggested_quantity}</td>
+                    <td>
+                      <input
+                        type="number"
+                        min="0"
+                        value={item.final_quantity}
+                        onChange={(e) =>
+                          updateFinalQty(item.item_id, e.target.value)
+                        }
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <button className="submit-btn" onClick={submitOrder}>
+              Submit Order
+            </button>
+          </>
+        )}
+      </div>
+    </>
+  );
+
 }

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -36,7 +36,7 @@ export default function GenerateRestockPage() {
           setErrorMsg("This order has already been submitted.");
           return;
         }
-        
+
         setOrder(res.data);
       } catch (err) {
         console.error("Failed to load order", err);
@@ -140,8 +140,10 @@ export default function GenerateRestockPage() {
         {order && (
           <p className="order-meta">
             Order #{order.id}{" "}
-            {order.submitted ? "submitted" : "created"} on{" "}
-            {new Date(order.created_at).toLocaleString()} by {currentUser.name}
+            {order.submitted
+              ? `submitted on ${new Date(order.submitted_at).toLocaleString()}`
+              : `created on ${new Date(order.created_at).toLocaleString()}`
+            } by {order.created_by?.name || "Unknown"}
           </p>
         )}
 

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -5,6 +5,8 @@ import "./GenerateRestockPage.css";
 import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import { useSearchParams } from "react-router-dom";
+import Sidebar from "../../components/Sidebar";
+import { FaBars } from "react-icons/fa";
 
 
 export default function GenerateRestockPage() {
@@ -16,6 +18,8 @@ export default function GenerateRestockPage() {
   const { orderId } = useParams(); // grab /restock/:orderId
   const [searchParams] = useSearchParams();
   const isReadOnly = searchParams.get("readonly") === "true";
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
 
 
   const navigate = useNavigate();
@@ -129,95 +133,113 @@ export default function GenerateRestockPage() {
 
 
   return (
-    <>
-      {showSuccess && (
-        <div className="toast-notification">
-          Order submitted and inventory updated!
+    <div className="main-content-wrapper">
+      <Sidebar
+        className={`sidebar ${sidebarOpen ? "open" : ""}`}
+        isOpen={sidebarOpen}
+        toggleSidebar={toggleSidebar}
+        user={currentUser}
+      />
+  
+      <div className="dashboard-container">
+        <div className="dashboard-header-container">
+          <div className="header-left">
+            <div className="sidebar-toggle-button" onClick={toggleSidebar}>
+              <FaBars size={24} />
+            </div>
+          </div>
+          <div className="header-center">
+            <h2 className="dashboard-header">Generate Restock Order</h2>
+          </div>
         </div>
-      )}
-
-      <div className="generate-restock-container">
-        {order && (
-          <p className="order-meta">
-            Order #{order.id}{" "}
-            {order.submitted
-              ? `submitted on ${new Date(order.submitted_at).toLocaleString()}`
-              : `created on ${new Date(order.created_at).toLocaleString()}`
-            } by {order.created_by?.name || "Unknown"}
-          </p>
+  
+        {showSuccess && (
+          <div className="toast-notification">
+            Order submitted and inventory updated!
+          </div>
         )}
-
-        {!order && (
-          <button onClick={generateOrder} disabled={loading}>
-            {loading ? "Generating..." : "Generate Restock Order"}
-          </button>
-        )}
-
-        {errorMsg && <p className="error-msg">{errorMsg}</p>}
-
-        {order && (
-          <>
-            <table className="restock-table">
-              <thead>
-                <tr>
-                  <th>Item Name</th>
-                  <th>Item ID</th>
-                  <th>Current Stock</th>
-                  <th>Withdrawn (7d)</th>
-                  <th>Suggested Qty</th>
-                  <th>Final Qty</th>
-                </tr>
-              </thead>
-              <tbody>
-                {order.order_items.map((item) => (
-                  <tr key={item.id}>
-                    <td>{item.item?.name || "Unknown"}</td>
-                    <td>{item.item_id}</td>
-                    <td>{item.item?.quantity ?? "?"}</td>
-                    <td>{item.withdrawn_7d ?? "0"}</td>
-                    <td>{item.suggested_quantity}</td>
-                    <td>
-                      {isReadOnly ? (
-                        <span>{item.final_quantity}</span>
-                      ) : (
-                        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "4px" }}>
-                          <button
-                            onClick={() => updateFinalQty(item.item_id, item.final_quantity - 1)}
-                            disabled={item.final_quantity <= 0}
-                          >
-                            -
-                          </button>
-                          <input
-                            type="text"
-                            inputMode="numeric"
-                            pattern="[0-9]*"
-                            value={item.final_quantity}
-                            onChange={(e) => updateFinalQty(item.item_id, e.target.value)}
-                          />
-                          <button
-                            onClick={() => updateFinalQty(item.item_id, item.final_quantity + 1)}
-                          >
-                            +
-                          </button>
-                        </div>
-                      )}
-                    </td>
-
-
+  
+        <div className="generate-restock-container">
+          {order && (
+            <p className="order-meta">
+              Order #{order.id}{" "}
+              {order.submitted
+                ? `submitted on ${new Date(order.submitted_at).toLocaleString()}`
+                : `created on ${new Date(order.created_at).toLocaleString()}`}
+              {" "}by {order.created_by?.name || "Unknown"}
+            </p>
+          )}
+  
+          {!order && (
+            <button onClick={generateOrder} disabled={loading}>
+              {loading ? "Generating..." : "Generate Restock Order"}
+            </button>
+          )}
+  
+          {errorMsg && <p className="error-msg">{errorMsg}</p>}
+  
+          {order && (
+            <>
+              <table className="restock-table">
+                <thead>
+                  <tr>
+                    <th>Item Name</th>
+                    <th>Item ID</th>
+                    <th>Current Stock</th>
+                    <th>Withdrawn (7d)</th>
+                    <th>Suggested Qty</th>
+                    <th>Final Qty</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-
-            {!isReadOnly && (
-              <button className="submit-btn" onClick={submitOrder}>
-                Submit Order
-              </button>
-            )}
-          </>
-        )}
+                </thead>
+                <tbody>
+                  {order.order_items.map((item) => (
+                    <tr key={item.id}>
+                      <td>{item.item?.name || "Unknown"}</td>
+                      <td>{item.item_id}</td>
+                      <td>{item.item?.quantity ?? "?"}</td>
+                      <td>{item.withdrawn_7d ?? "0"}</td>
+                      <td>{item.suggested_quantity}</td>
+                      <td>
+                        {isReadOnly ? (
+                          <span>{item.final_quantity}</span>
+                        ) : (
+                          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "4px" }}>
+                            <button
+                              onClick={() => updateFinalQty(item.item_id, item.final_quantity - 1)}
+                              disabled={item.final_quantity <= 0}
+                            >
+                              -
+                            </button>
+                            <input
+                              type="text"
+                              inputMode="numeric"
+                              pattern="[0-9]*"
+                              value={item.final_quantity}
+                              onChange={(e) => updateFinalQty(item.item_id, e.target.value)}
+                            />
+                            <button
+                              onClick={() => updateFinalQty(item.item_id, item.final_quantity + 1)}
+                            >
+                              +
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+  
+              {!isReadOnly && (
+                <button className="submit-btn" onClick={submitOrder}>
+                  Submit Order
+                </button>
+              )}
+            </>
+          )}
+        </div>
       </div>
-    </>
-  );
+    </div>
+  );  
 
 }

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -164,7 +164,7 @@ export default function GenerateRestockPage() {
             <p className="order-meta">
               Order #{order.id}{" "}
               {order.submitted
-                ? `submitted on ${new Date(order.submitted_at).toLocaleString()}`
+                ? `submitted on ${new Date(order.submitted_at + "Z").toLocaleString()}`
                 : `created on ${new Date(order.created_at).toLocaleString()}`}
               {" "}by {order.created_by?.name || "Unknown"}
             </p>

--- a/frontend/src/pages/admin/GenerateRestockPage.jsx
+++ b/frontend/src/pages/admin/GenerateRestockPage.jsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router-dom";
 import { useSearchParams } from "react-router-dom";
 import Sidebar from "../../components/Sidebar";
 import { FaBars } from "react-icons/fa";
+import { FaHome } from "react-icons/fa";
 
 
 export default function GenerateRestockPage() {
@@ -140,7 +141,7 @@ export default function GenerateRestockPage() {
         toggleSidebar={toggleSidebar}
         user={currentUser}
       />
-  
+
       <div className="dashboard-container">
         <div className="dashboard-header-container">
           <div className="header-left">
@@ -151,14 +152,24 @@ export default function GenerateRestockPage() {
           <div className="header-center">
             <h2 className="dashboard-header">Generate Restock Order</h2>
           </div>
+          {/* Right: Home Icon */}
+          <div className="header-right">
+            <div
+              className="cart-icon-container"
+              onClick={() => navigate("/admin/dashboard")}
+            >
+              <FaHome className="cart-icon" />
+            </div>
+          </div>
+
         </div>
-  
+
         {showSuccess && (
           <div className="toast-notification">
             Order submitted and inventory updated!
           </div>
         )}
-  
+
         <div className="generate-restock-container">
           {order && (
             <p className="order-meta">
@@ -169,15 +180,15 @@ export default function GenerateRestockPage() {
               {" "}by {order.created_by?.name || "Unknown"}
             </p>
           )}
-  
+
           {!order && (
             <button onClick={generateOrder} disabled={loading}>
               {loading ? "Generating..." : "Generate Restock Order"}
             </button>
           )}
-  
+
           {errorMsg && <p className="error-msg">{errorMsg}</p>}
-  
+
           {order && (
             <>
               <table className="restock-table">
@@ -229,7 +240,7 @@ export default function GenerateRestockPage() {
                   ))}
                 </tbody>
               </table>
-  
+
               {!isReadOnly && (
                 <button className="submit-btn" onClick={submitOrder}>
                   Submit Order
@@ -240,6 +251,6 @@ export default function GenerateRestockPage() {
         </div>
       </div>
     </div>
-  );  
+  );
 
 }

--- a/frontend/src/pages/admin/PastRestockPage.css
+++ b/frontend/src/pages/admin/PastRestockPage.css
@@ -24,3 +24,9 @@
     border-radius: 4px;
   }
   
+  .no-orders-msg {
+    margin-top: 2rem;
+    font-size: 1.2rem;
+    color: #777;
+    text-align: center;
+  }

--- a/frontend/src/pages/admin/PastRestockPage.css
+++ b/frontend/src/pages/admin/PastRestockPage.css
@@ -1,0 +1,26 @@
+.orders-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+  
+  .orders-table th,
+  .orders-table td {
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+  }
+  
+  .orders-table .draft {
+    background-color: #fff8dc;
+  }
+  
+  .toast-notification {
+    background-color: #28a745;
+    color: white;
+    text-align: center;
+    padding: 10px;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+  }
+  

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -84,10 +84,12 @@ export default function PastRestockPage() {
               <td>
                 {order.submitted ? (
                   <button
-                    onClick={() => navigate(`/admin/dashboard/order/${order.id}`)}
-                  >
-                    View
-                  </button>
+                  onClick={() =>
+                    navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
+                  }
+                >
+                  View
+                </button>
                 ) : (
                   <>
                     <button

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import "./PastRestockPage.css";
 import Sidebar from "../../components/Sidebar";
 import { FaBars } from "react-icons/fa";
+import "../Pagination.css";
 
 export default function PastRestockPage() {
   const { currentUser } = useAuth();
@@ -14,6 +15,10 @@ export default function PastRestockPage() {
   const [toastMsg, setToastMsg] = useState("");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const toggleSidebar = () => setSidebarOpen((prev) => !prev);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const itemsPerPage = 10; // Number of items per page
+
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -60,6 +65,12 @@ export default function PastRestockPage() {
     }
   };
 
+  // Pagination
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = orders.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(orders.length / itemsPerPage);
+
   return (
     <div className="main-content-wrapper">
       <Sidebar
@@ -95,7 +106,7 @@ export default function PastRestockPage() {
               </tr>
             </thead>
             <tbody>
-              {orders.map((order) => (
+              {currentItems.map((order) => (
                 <tr key={order.id} className={!order.submitted ? "draft" : ""}>
                   <td>{order.id}</td>
                   <td>{new Date(order.created_at).toLocaleString()}</td>
@@ -131,6 +142,23 @@ export default function PastRestockPage() {
               ))}
             </tbody>
           </table>
+          <div className="pagination-container">
+            <button
+              onClick={() => setCurrentPage(currentPage - 1)}
+              disabled={currentPage === 1}
+            >
+              Previous
+            </button>
+            <span className="page-info">
+              {currentPage} / {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage(currentPage + 1)}
+              disabled={currentPage === totalPages}
+            >
+              Next
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -80,7 +80,7 @@ export default function PastRestockPage() {
         toggleSidebar={toggleSidebar}
         user={currentUser}
       />
-
+  
       <div className="dashboard-container">
         <div className="dashboard-header-container">
           <div className="header-left">
@@ -88,9 +88,11 @@ export default function PastRestockPage() {
               <FaBars size={24} />
             </div>
           </div>
+  
           <div className="header-center">
             <h2 className="dashboard-header">Past Restock Orders</h2>
           </div>
+  
           {/* Right: Home Icon */}
           <div className="header-right">
             <div
@@ -100,12 +102,11 @@ export default function PastRestockPage() {
               <FaHome className="cart-icon" />
             </div>
           </div>
-
         </div>
-
+  
         <div className="past-orders-page">
           {showToast && <div className="toast-notification">{toastMsg}</div>}
-
+  
           {orders.length === 0 ? (
             <p className="no-orders-msg">No restock orders available yet.</p>
           ) : (
@@ -130,7 +131,9 @@ export default function PastRestockPage() {
                           ? new Date(order.submitted_at + "Z").toLocaleString()
                           : "---"}
                       </td>
-                      <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
+                      <td>
+                        {order.created_by?.name || order.created_by?.email || "Unknown"}
+                      </td>
                       <td>
                         {order.submitted ? (
                           <button
@@ -149,7 +152,9 @@ export default function PastRestockPage() {
                             >
                               Continue
                             </button>
-                            <button onClick={() => deleteOrder(order.id)}>Delete</button>
+                            <button onClick={() => deleteOrder(order.id)}>
+                              Delete
+                            </button>
                           </>
                         )}
                       </td>
@@ -157,28 +162,30 @@ export default function PastRestockPage() {
                   ))}
                 </tbody>
               </table>
-
-              <div className="pagination-container">
-                <button
-                  onClick={() => setCurrentPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                >
-                  Previous
-                </button>
-                <span className="page-info">
-                  {currentPage} / {totalPages}
-                </span>
-                <button
-                  onClick={() => setCurrentPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                >
-                  Next
-                </button>
-              </div>
+  
+              {orders.length > 0 && (
+                <div className="pagination-container">
+                  <button
+                    onClick={() => setCurrentPage(currentPage - 1)}
+                    disabled={currentPage === 1}
+                  >
+                    Previous
+                  </button>
+                  <span className="page-info">
+                    {currentPage} / {totalPages}
+                  </span>
+                  <button
+                    onClick={() => setCurrentPage(currentPage + 1)}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
             </>
           )}
         </div>
       </div>
     </div>
-  );
+  );  
 }

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -101,7 +101,7 @@ export default function PastRestockPage() {
                   <td>{new Date(order.created_at).toLocaleString()}</td>
                   <td>
                     {order.submitted && order.submitted_at
-                      ? new Date(order.submitted_at).toLocaleString()
+                      ? new Date(order.submitted_at + "Z").toLocaleString()
                       : "---"}
                   </td>
                   <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -17,10 +17,16 @@ export default function PastRestockPage() {
         const res = await axios.get("http://localhost:8000/orders/", {
           headers: { Authorization: `Bearer ${currentUser.token}` },
         });
-
-        const sorted = res.data.sort(
-          (a, b) => new Date(b.created_at) - new Date(a.created_at)
-        );
+    
+        const sorted = res.data.sort((a, b) => {
+          // Drafts not submittedgo first
+          if (a.submitted !== b.submitted) {
+            return a.submitted ? 1 : -1;
+          }
+          //  sort by created_at descending
+          return new Date(b.created_at) - new Date(a.created_at);
+        });
+    
         setOrders(sorted);
       } catch (err) {
         console.error("Failed to fetch orders", err);

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -17,7 +17,7 @@ export default function PastRestockPage() {
         const res = await axios.get("http://localhost:8000/orders/", {
           headers: { Authorization: `Bearer ${currentUser.token}` },
         });
-    
+
         const sorted = res.data.sort((a, b) => {
           // Drafts not submittedgo first
           if (a.submitted !== b.submitted) {
@@ -26,7 +26,7 @@ export default function PastRestockPage() {
           //  sort by created_at descending
           return new Date(b.created_at) - new Date(a.created_at);
         });
-    
+
         setOrders(sorted);
       } catch (err) {
         console.error("Failed to fetch orders", err);
@@ -76,20 +76,20 @@ export default function PastRestockPage() {
               <td>{order.id}</td>
               <td>{new Date(order.created_at).toLocaleString()}</td>
               <td>
-                {order.submitted && order.created_at
-                  ? new Date(order.created_at).toLocaleString()
+                {order.submitted && order.submitted_at
+                  ? new Date(order.submitted_at).toLocaleString()
                   : "---"}
               </td>
               <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
               <td>
                 {order.submitted ? (
                   <button
-                  onClick={() =>
-                    navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
-                  }
-                >
-                  View
-                </button>
+                    onClick={() =>
+                      navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
+                    }
+                  >
+                    View
+                  </button>
                 ) : (
                   <>
                     <button

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -6,6 +6,7 @@ import "./PastRestockPage.css";
 import Sidebar from "../../components/Sidebar";
 import { FaBars } from "react-icons/fa";
 import "../Pagination.css";
+import { FaHome } from "react-icons/fa";
 
 export default function PastRestockPage() {
   const { currentUser } = useAuth();
@@ -79,7 +80,7 @@ export default function PastRestockPage() {
         toggleSidebar={toggleSidebar}
         user={currentUser}
       />
-  
+
       <div className="dashboard-container">
         <div className="dashboard-header-container">
           <div className="header-left">
@@ -90,11 +91,21 @@ export default function PastRestockPage() {
           <div className="header-center">
             <h2 className="dashboard-header">Past Restock Orders</h2>
           </div>
+          {/* Right: Home Icon */}
+          <div className="header-right">
+            <div
+              className="cart-icon-container"
+              onClick={() => navigate("/admin/dashboard")}
+            >
+              <FaHome className="cart-icon" />
+            </div>
+          </div>
+
         </div>
-  
+
         <div className="past-orders-page">
           {showToast && <div className="toast-notification">{toastMsg}</div>}
-  
+
           {orders.length === 0 ? (
             <p className="no-orders-msg">No restock orders available yet.</p>
           ) : (
@@ -146,7 +157,7 @@ export default function PastRestockPage() {
                   ))}
                 </tbody>
               </table>
-  
+
               <div className="pagination-container">
                 <button
                   onClick={() => setCurrentPage(currentPage - 1)}
@@ -169,5 +180,5 @@ export default function PastRestockPage() {
         </div>
       </div>
     </div>
-  );  
+  );
 }

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -1,4 +1,86 @@
-// PastRestockPage.jsx
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useAuth } from "../../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import "./PastRestockPage.css";
+
 export default function PastRestockPage() {
-  return <h1>Past Restock Orders Page</h1>;
+  const { currentUser } = useAuth();
+  const navigate = useNavigate();
+  const [orders, setOrders] = useState([]);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMsg, setToastMsg] = useState("");
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      const res = await axios.get("http://localhost:8000/orders/", {
+        headers: { Authorization: `Bearer ${currentUser.token}` },
+      });
+      const sorted = res.data.sort(
+        (a, b) => new Date(b.created_at) - new Date(a.created_at)
+      );
+      setOrders(sorted);
+    };
+    fetchOrders();
+  }, [currentUser.token]);
+
+  const deleteOrder = async (id) => {
+    const confirmed = window.confirm(
+      `Are you sure you want to delete Order #${id}?`
+    );
+    if (!confirmed) return;
+
+    await axios.delete(`http://localhost:8000/orders/${id}`, {
+      headers: { Authorization: `Bearer ${currentUser.token}` },
+    });
+
+    setOrders((prev) => prev.filter((o) => o.id !== id));
+    setToastMsg(`Order #${id} successfully deleted.`);
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 3000);
+  };
+
+  return (
+    <div className="past-orders-page">
+      {showToast && <div className="toast-notification">{toastMsg}</div>}
+      <h2>Past Restock Orders</h2>
+      <table className="orders-table">
+        <thead>
+          <tr>
+            <th>Order ID</th>
+            <th>Created At</th>
+            <th>Submitted At</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <tr key={order.id} className={!order.submitted ? "draft" : ""}>
+              <td>{order.id}</td>
+              <td>{new Date(order.created_at).toLocaleString()}</td>
+              <td>
+                {order.submitted
+                  ? new Date(order.created_at).toLocaleString()
+                  : "---"}
+              </td>
+              <td>
+                {order.submitted ? (
+                  <button onClick={() => navigate(`/admin/dashboard/order/${order.id}`)}>
+                    View
+                  </button>
+                ) : (
+                  <>
+                    <button onClick={() => navigate(`/admin/dashboard/restock/${order.id}`)}>
+                      Continue
+                    </button>
+                    <button onClick={() => deleteOrder(order.id)}>Delete</button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -3,6 +3,8 @@ import axios from "axios";
 import { useAuth } from "../../contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import "./PastRestockPage.css";
+import Sidebar from "../../components/Sidebar";
+import { FaBars } from "react-icons/fa";
 
 export default function PastRestockPage() {
   const { currentUser } = useAuth();
@@ -10,6 +12,8 @@ export default function PastRestockPage() {
   const [orders, setOrders] = useState([]);
   const [showToast, setShowToast] = useState(false);
   const [toastMsg, setToastMsg] = useState("");
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -57,56 +61,78 @@ export default function PastRestockPage() {
   };
 
   return (
-    <div className="past-orders-page">
-      {showToast && <div className="toast-notification">{toastMsg}</div>}
-      <h2>Past Restock Orders</h2>
-      <table className="orders-table">
-        <thead>
-          <tr>
-            <th>Order ID</th>
-            <th>Created At</th>
-            <th>Submitted At</th>
-            <th>Created By</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map((order) => (
-            <tr key={order.id} className={!order.submitted ? "draft" : ""}>
-              <td>{order.id}</td>
-              <td>{new Date(order.created_at).toLocaleString()}</td>
-              <td>
-                {order.submitted && order.submitted_at
-                  ? new Date(order.submitted_at).toLocaleString()
-                  : "---"}
-              </td>
-              <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
-              <td>
-                {order.submitted ? (
-                  <button
-                    onClick={() =>
-                      navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
-                    }
-                  >
-                    View
-                  </button>
-                ) : (
-                  <>
-                    <button
-                      onClick={() =>
-                        navigate(`/admin/dashboard/restock/${order.id}`)
-                      }
-                    >
-                      Continue
-                    </button>
-                    <button onClick={() => deleteOrder(order.id)}>Delete</button>
-                  </>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="main-content-wrapper">
+      <Sidebar
+        className={`sidebar ${sidebarOpen ? "open" : ""}`}
+        isOpen={sidebarOpen}
+        toggleSidebar={toggleSidebar}
+        user={currentUser}
+      />
+
+      <div className="dashboard-container">
+        <div className="dashboard-header-container">
+          <div className="header-left">
+            <div className="sidebar-toggle-button" onClick={toggleSidebar}>
+              <FaBars size={24} />
+            </div>
+          </div>
+          <div className="header-center">
+            <h2 className="dashboard-header">Past Restock Orders</h2>
+          </div>
+        </div>
+
+        <div className="past-orders-page">
+          {showToast && <div className="toast-notification">{toastMsg}</div>}
+
+          <table className="orders-table">
+            <thead>
+              <tr>
+                <th>Order ID</th>
+                <th>Created At</th>
+                <th>Submitted At</th>
+                <th>Created By</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((order) => (
+                <tr key={order.id} className={!order.submitted ? "draft" : ""}>
+                  <td>{order.id}</td>
+                  <td>{new Date(order.created_at).toLocaleString()}</td>
+                  <td>
+                    {order.submitted && order.submitted_at
+                      ? new Date(order.submitted_at).toLocaleString()
+                      : "---"}
+                  </td>
+                  <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
+                  <td>
+                    {order.submitted ? (
+                      <button
+                        onClick={() =>
+                          navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
+                        }
+                      >
+                        View
+                      </button>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() =>
+                            navigate(`/admin/dashboard/restock/${order.id}`)
+                          }
+                        >
+                          Continue
+                        </button>
+                        <button onClick={() => deleteOrder(order.id)}>Delete</button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/admin/PastRestockPage.jsx
+++ b/frontend/src/pages/admin/PastRestockPage.jsx
@@ -79,7 +79,7 @@ export default function PastRestockPage() {
         toggleSidebar={toggleSidebar}
         user={currentUser}
       />
-
+  
       <div className="dashboard-container">
         <div className="dashboard-header-container">
           <div className="header-left">
@@ -91,76 +91,83 @@ export default function PastRestockPage() {
             <h2 className="dashboard-header">Past Restock Orders</h2>
           </div>
         </div>
-
+  
         <div className="past-orders-page">
           {showToast && <div className="toast-notification">{toastMsg}</div>}
-
-          <table className="orders-table">
-            <thead>
-              <tr>
-                <th>Order ID</th>
-                <th>Created At</th>
-                <th>Submitted At</th>
-                <th>Created By</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {currentItems.map((order) => (
-                <tr key={order.id} className={!order.submitted ? "draft" : ""}>
-                  <td>{order.id}</td>
-                  <td>{new Date(order.created_at).toLocaleString()}</td>
-                  <td>
-                    {order.submitted && order.submitted_at
-                      ? new Date(order.submitted_at + "Z").toLocaleString()
-                      : "---"}
-                  </td>
-                  <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
-                  <td>
-                    {order.submitted ? (
-                      <button
-                        onClick={() =>
-                          navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
-                        }
-                      >
-                        View
-                      </button>
-                    ) : (
-                      <>
-                        <button
-                          onClick={() =>
-                            navigate(`/admin/dashboard/restock/${order.id}`)
-                          }
-                        >
-                          Continue
-                        </button>
-                        <button onClick={() => deleteOrder(order.id)}>Delete</button>
-                      </>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className="pagination-container">
-            <button
-              onClick={() => setCurrentPage(currentPage - 1)}
-              disabled={currentPage === 1}
-            >
-              Previous
-            </button>
-            <span className="page-info">
-              {currentPage} / {totalPages}
-            </span>
-            <button
-              onClick={() => setCurrentPage(currentPage + 1)}
-              disabled={currentPage === totalPages}
-            >
-              Next
-            </button>
-          </div>
+  
+          {orders.length === 0 ? (
+            <p className="no-orders-msg">No restock orders available yet.</p>
+          ) : (
+            <>
+              <table className="orders-table">
+                <thead>
+                  <tr>
+                    <th>Order ID</th>
+                    <th>Created At</th>
+                    <th>Submitted At</th>
+                    <th>Created By</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {currentItems.map((order) => (
+                    <tr key={order.id} className={!order.submitted ? "draft" : ""}>
+                      <td>{order.id}</td>
+                      <td>{new Date(order.created_at).toLocaleString()}</td>
+                      <td>
+                        {order.submitted && order.submitted_at
+                          ? new Date(order.submitted_at + "Z").toLocaleString()
+                          : "---"}
+                      </td>
+                      <td>{order.created_by?.name || order.created_by?.email || "Unknown"}</td>
+                      <td>
+                        {order.submitted ? (
+                          <button
+                            onClick={() =>
+                              navigate(`/admin/dashboard/restock/${order.id}?readonly=true`)
+                            }
+                          >
+                            View
+                          </button>
+                        ) : (
+                          <>
+                            <button
+                              onClick={() =>
+                                navigate(`/admin/dashboard/restock/${order.id}`)
+                              }
+                            >
+                              Continue
+                            </button>
+                            <button onClick={() => deleteOrder(order.id)}>Delete</button>
+                          </>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+  
+              <div className="pagination-container">
+                <button
+                  onClick={() => setCurrentPage(currentPage - 1)}
+                  disabled={currentPage === 1}
+                >
+                  Previous
+                </button>
+                <span className="page-info">
+                  {currentPage} / {totalPages}
+                </span>
+                <button
+                  onClick={() => setCurrentPage(currentPage + 1)}
+                  disabled={currentPage === totalPages}
+                >
+                  Next
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>
-  );
+  );  
 }

--- a/frontend/src/routes/AdminRoutes.jsx
+++ b/frontend/src/routes/AdminRoutes.jsx
@@ -21,6 +21,7 @@ export default function AdminRoutes() {
       <Route path="transactions" element={<PastTransactionsPage />} />
       <Route path="analytics" element={<AnalyticsPage />} />
       <Route path="restock" element={<GenerateRestockPage />} />
+      <Route path="restock/:orderId" element={<GenerateRestockPage />} />
       <Route path="past-restocks" element={<PastRestockPage />} />
       <Route path="transaction-report" element={<TransactionReportPage />} />
       <Route path="export-cv" element={<ExportCVPage />} />


### PR DESCRIPTION
## Admin Restock Workflow

**Generate Restock Order** – creates a new order based on low stock and popular items

**View Past Orders** – shows both submitted and draft orders with details

---

This PR introduces a full admin interface for restocking inventory
- generate a new restock order
- save drafts
- submit finalized orders
- view past restock orders

---
### Generate Restock Order Page
- Automatically calculates suggested quantities
- Admin can adjust Final Qty before submitting
- Submitting the order updates inventory and marks it as finalized
- If the admin navigates away before submitting, the order is saved as a draft

---
### Past Restock Orders Page
- Draft orders appear at the top of the list (no submitted time)
- Each order shows:
    - Created At timestamp
    - Submitted At timestamp (if applicable)
    - Created By user
    - Action for Drafts: Can be resumed (Continue) or deleted (`Continue` or `Delete` button)
    - Action for Submitted Orders: Read-only view, shows what was ordered (`View` button)
 
Note: Schema was updated. there is a `submitted_at` column for `orders` table now. Created and submitted time were showing up at the same time, I had to make a new column for submitted so the correct times appear.
Please update with `mysql -u root -p inventory < database/main.sql`

![image](https://github.com/user-attachments/assets/ad31cede-c576-4d0b-9602-eb7d1f239ffc)

![image](https://github.com/user-attachments/assets/b02731d1-0548-492c-84fa-d8b168fbe358)


